### PR TITLE
Fix missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ plotly
 
 # Utility Libraries
 pathlib2
+faker
 
 # Optional: For enhanced Excel export functionality
 # openpyxl


### PR DESCRIPTION
## Summary
- include `faker` module in requirements

## Testing
- `python -m py_compile app.py scripts/Heat_map.py scripts/generate_bookings.py`

------
https://chatgpt.com/codex/tasks/task_b_685015a2840c83339960fe4c71936898